### PR TITLE
v0.3.0

### DIFF
--- a/.clasp.json
+++ b/.clasp.json
@@ -1,2 +1,1 @@
-{"scriptId":"13wWdtigtpyz-M3R42XdhSHdZ3s9txGcHURwNzCT3LBair-ohZtdMUHMz","rootDir":"./dist"}
-
+{"scriptId":"1L-oRI-HTAgLOLA11Weh1qV3US8IZ5F_9hEImdCEb_OOJXbYV6dx5kOwf","rootDir":"./dist"}

--- a/.clasp.json
+++ b/.clasp.json
@@ -1,2 +1,2 @@
-{"scriptId":"19gnnksefG7Jm4SO7v0GBUyDfiuBBv-jmws1Y1LY4qQx6c6UippAIVqPD","rootDir":"./dist"}
+{"scriptId":"13wWdtigtpyz-M3R42XdhSHdZ3s9txGcHURwNzCT3LBair-ohZtdMUHMz","rootDir":"./dist"}
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,26 @@
+## Installing from code
+
+Enable [Google Apps Script API](https://script.google.com/home/usersettings).
+
+Update `Node.js` and `npm`
+```bash
+$ curl -fsSL https://deb.nodesource.com/setup_19.x | sudo -E bash - && sudo apt-get install -y nodejs
+$ sudo npm install npm -g
+```
+
+Install `clasp`
+```bash
+$ sudo npm i @google/clasp@2.3.0 -g
+```
+
+Create with a new Google Spreadsheet with the script.
+```bash
+$ npx clasp create --type sheets --title "IGVF Metadata Submitter v0.3.0" --rootDir ./dist
+```
+
+Get the script ID from the output and edit `scriptId` in `.clasp.json`.
+
+Deploy the script to the created sheet. Whenver you make changes to the code, run this to update the code in Google Apps Script.
+```bash
+$ npm run deploy
+```

--- a/README.md
+++ b/README.md
@@ -3,62 +3,31 @@
 IGVF metadata submitter based on Google Sheet + Google Apps Script.
 
 
-## Limitation
-
-This script is heavily based on Google Apps Script(GAP)'s URL fetch call to communicate with the portal. GAP is free but has some limit/quota. Check quota [here](https://developers.google.com/apps-script/guides/services/quotas). It's limited to `20,000` URL fetch calls a day. It's `100,000` for Google Workspace users (it costs $6 per month).
-
 ## Installation
 
-You can install it from code or make a copy from a portable version.
-
-## Installing from code
-
-Enable [Google Apps Script API](https://script.google.com/home/usersettings).
-
-Update `Node.js` and `npm`
-```bash
-$ curl -fsSL https://deb.nodesource.com/setup_19.x | sudo -E bash - && sudo apt-get install -y nodejs
-$ sudo npm install npm -g
-```
-
-Install `clasp`
-```bash
-$ sudo npm i @google/clasp@2.3.0 -g
-```
-
-Create with a new Google Spreadsheet with the script.
-```bash
-$ npx clasp create --type sheets --title "IGVF Metadata Submitter v0.3.0" --rootDir ./dist
-```
-
-Get the script ID from the output and edit `scriptId` in `.clasp.json`.
-
-Deploy the script to the created sheet. Whenver you make changes to the code, run this to update the code in Google Apps Script.
-```bash
-$ npm run deploy
-```
-
-## Cloning a portable version (user)
-
-Make a copy of this portable version and grant any required permissions.
+Make a copy of the following spreadsheet and grant any required permissions. Then refresh the cloned spreadsheet page.
 
 `v0.3.0`: https://docs.google.com/spreadsheets/d/1gWEHGdi0eNjaX1mmC3FrgHFntfhWMib3ipQeas3ukzI/edit?usp=sharing
 
+To build and deploy a new spreadsheet, see [INSTALL.md](INSTALL.md).
+
+
 ## Settings
 
-You can configure the submitter either globally or for a specific sheet.
+Authorization and endpoint are global settings. Profile name should be defined for each sheet.
 
 ### Authorization
 
-Authorize on ENCODE and IGVF portal. Get a username/password pair from portal's `Profile` menu.
+Get a key/serect pair from portal's `Profile` menu. Click on menu `Authorize for IGVF` and enter them.
 
-### Endpoints
+### Endpoint
 
-There are two endpoints for READ and WRITE. READ actions (GET, getting profile schema JSON) send requests to the READ endpoint and WRITE actions (PATCH, POST, PUT) send requests to the WRITE endpoint.
+We provide multiple endpoints to communicate with the portal. Click on menu `Set endpoint` and enter supported endpoints.
 
 ### Profile
 
-Name of a profile. Only `snake_case` or capitalized `CamelCase` works. For example, `experiment`, `Lab`, `human_donor` and `MouseDonor`.
+You need to set a profile for each sheet in the spreadsheet. For each sheet, click on menu `Set profile name`. Only `snake_case` or capitalized `CamelCase` works. For example, `measurement_set`, `award` and `Lab`.
+
 
 ## Functions
 
@@ -80,11 +49,12 @@ PATCH will send a patch request to the portal in order to patch properties of **
 
 POST sends a POST request to the portal. Use this to submit a new metadata and generate an accession/ID.
 
-### PUT
+### PUT (Admin only)
 
 PUT sends a PUT request to the portal so that the whole metadata on the portal is replaced with a row on the sheet. **Beware that this will remove any missing properties on the sheet from the portal**.
 
 Before you PUT to the portal, make sure to GET the metadata with GET (ADMIN) first.
+
 
 ## Property legends
 
@@ -102,7 +72,8 @@ Color and style represents a type of property.
 - <span style="text-decoration:underline">Underline</span>: Searchable property
 - ***Italic+Bold***: Array type property
 
-### File upload sidebar
+
+## File upload sidebar
 
 You can directly upload local files to portal's S3 bucket on the upload sidebar. Use it after POSTing metadata to the portal. Make sure that there is at least one identifying property in the header (e.g. `accession`, `uuid`).
 
@@ -114,7 +85,8 @@ Click on menu `IGVF/ENCODE` - `Upload sidebar` and read the instruction carefull
 
 You need to drag and drop a root folder that contains all files to be uploaded. Such action is necessary to grant read permission of files to the sidebar. Therefore, make sure that all files are organized under a single root directory.
 
-### Attachment
+
+## Attachment
 
 For a profile with `attachment` property (e.g. `document` profile), you can define `attachment` column as a JSON string `{"path":"/GOOGLE/DRIVE/PATH/TO/FILE/me.pdf"}`.
 

--- a/README.md
+++ b/README.md
@@ -113,3 +113,9 @@ Click on menu `IGVF/ENCODE` - `Upload sidebar` and read the instruction carefull
 `#upload_cmd` is optional for manual uploading using S3 CLI. If you want to upload from a remote server via AWS CLI, then drag and drop any empty folder and click on the initialize button. Make sure that `--body` parameter in `#upload_cmd` points to a correct path on a remote server.
 
 You need to drag and drop a root folder that contains all files to be uploaded. Such action is necessary to grant read permission of files to the sidebar. Therefore, make sure that all files are organized under a single root directory.
+
+### Attachment
+
+For a profile with `attachment` property (e.g. `document` profile), you can define `attachment` column as a JSON string `{"path":"/GOOGLE/DRIVE/PATH/TO/FILE/me.pdf"}`.
+
+It is recommended to make a local directory for document files only on your computer, and then drag and drop the folder itself to your Google Drive. Then all files in it will be transferred to Google Drive while keeping the directory structure.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Make a copy of the following spreadsheet and grant any required permissions. The
 
 `v0.3.0`: https://docs.google.com/spreadsheets/d/1gWEHGdi0eNjaX1mmC3FrgHFntfhWMib3ipQeas3ukzI/edit?usp=sharing
 
-To build and deploy a new spreadsheet, see [INSTALL.md](INSTALL.md).
+To build and deploy a new spreadsheet from the code, see [INSTALL.md](INSTALL.md).
 
 
 ## Settings
@@ -18,7 +18,7 @@ Authorization and endpoint are global settings. Profile name should be defined f
 
 ### Authorization
 
-Get a key/serect pair from portal's `Profile` menu. Click on menu `Authorize for IGVF` and enter them.
+Get a key/secret pair from portal's `Profile` menu. Click on menu `Authorize for IGVF` and enter them.
 
 ### Endpoint
 
@@ -26,7 +26,7 @@ We provide multiple endpoints to communicate with the portal. Click on menu `Set
 
 ### Profile
 
-You need to set a profile for each sheet in the spreadsheet. For each sheet, click on menu `Set profile name`. Only `snake_case` or capitalized `CamelCase` works. For example, `measurement_set`, `award` and `Lab`.
+You need to set a profile for each sheet in the spreadsheet. For each sheet, click on menu `Set profile name`. Only `snake_case` or capitalized `CamelCase` works. For example, `measurement_set`, `sequence_file`, `award` and `Lab`.
 
 
 ## Functions
@@ -77,13 +77,9 @@ Color and style represents a type of property.
 
 You can directly upload local files to portal's S3 bucket on the upload sidebar. Use it after POSTing metadata to the portal. Make sure that there is at least one identifying property in the header (e.g. `accession`, `uuid`).
 
-Add three commented columns `#upload_status`, `#upload_abspath` and `#upload_cmd` to the sheet. `#upload_status` will be automatically updated while uploading. `#upload_abspath` is to define absolue path of files to be uploaded.
+Click on menu `IGVF/ENCODE` - `Upload local files (sidebar)` and it will automatically create two columns to a current sheet: `#upload_status` and `#upload_abspath`. Define absolute paths of files to be uploaded under the column #`#upload_abspath`. `#upload_status` will show uploading status.
 
-Click on menu `IGVF/ENCODE` - `Upload sidebar` and read the instruction carefully. 
-
-`#upload_cmd` is optional for manual uploading using S3 CLI. If you want to upload from a remote server via AWS CLI, then drag and drop any empty folder and click on the initialize button. Make sure that `--body` parameter in `#upload_cmd` points to a correct path on a remote server.
-
-You need to drag and drop a root folder that contains all files to be uploaded. Such action is necessary to grant read permission of files to the sidebar. Therefore, make sure that all files are organized under a single root directory.
+On the sidebar, you need to drag and drop a root folder that contains all files to be uploaded. Such action is necessary to grant read permission of files to the sidebar. Therefore, make sure that all files are organized under a single root directory.
 
 
 ## Attachment

--- a/README.md
+++ b/README.md
@@ -5,55 +5,81 @@ IGVF metadata submitter based on Google Sheet + Google Apps Script.
 
 ## Installation
 
-Make a copy of the following spreadsheet and grant any required permissions. Then refresh the cloned spreadsheet page.
+Make a copy of the following spreadsheet.
 
 `v0.3.0`: https://docs.google.com/spreadsheets/d/1gWEHGdi0eNjaX1mmC3FrgHFntfhWMib3ipQeas3ukzI/edit?usp=sharing
 
-To build and deploy a new spreadsheet from the code, see [INSTALL.md](INSTALL.md).
+Click on the menu item `IGVF` and then `Authorize for IGVF`. You will see an error message `Authorization Required`. Click on `Continue`, choose your Google account. Click on `Advanced` and `Go to IGVF Metadata Submitter (unsafe)` and then click on `Allow`.
 
-
-## Settings
-
-Authorization and endpoint are global settings. Profile name should be defined for each sheet.
+To build and deploy a new spreadsheet directly from a code, see [INSTALL.md](INSTALL.md).
 
 ### Authorization
 
-Get a key/secret pair from portal's `Profile` menu. Click on menu `Authorize for IGVF` and enter them.
+Get a key/secret pair from portal's `Profile` menu. Click on menu `Authorize for IGVF` and enter credentials.
+
 
 ### Endpoint
 
-We provide multiple endpoints to communicate with the portal. Click on menu `Set endpoint` and enter supported endpoints.
+Click on menu `Set endpoint`. We provide multiple endpoints to communicate with the portal. For example, `https://api.sandbox.igvf.org` is an endpoint for testing purpose and `https://api.data.igvf.org` is for production. Click on menu `Set endpoint` and enter supported endpoints.
+
 
 ### Profile
 
-You need to set a profile for each sheet in the spreadsheet. For each sheet, click on menu `Set profile name`. Only `snake_case` or capitalized `CamelCase` works. For example, `measurement_set`, `sequence_file`, `award` and `Lab`.
+Create a new sheet and click on menu `Set endpoint`. An endpoint is set for each sheet. Only `snake_case` (recommended) or capitalized `CamelCase` works. For example, `measurement_set`, `sequence_file`, `award` and `Lab`. The script will automatically create a template row for the given profile.
 
 
 ## Functions
 
-This section describes how to use each function. This metadata submitter converts each row into a JSON object and then submit it to the portal.
+This metadata submitter converts each row into a JSON object and then submit it to the portal.
 
-You can skip a row by setting `#skip` column as `1` or by hiding the row itself (right-click on the selected rows and `Hide`).
+You can skip any row by setting `#skip` column as `1` or by hiding the row itself (right-click on the selected rows and `Hide`).
 
-Also, if cell's value is empty for a certain property then such property is not included in the JSON object when being sent to the portal.
+Also, if cell's value is empty for a certain property then such property is simply ignored (not included in the JSON object when being sent to the portal).
 
 ### GET
 
 GET will send a GET request to the portal and will convert retrieved metadata to a row on the sheet.
 
-### PATCH
-
-PATCH will send a patch request to the portal in order to patch properties of **SELECTED** columns. Only selected columns will be affected by this request. Properties in other columns will not be included in the request.
-
 ### POST
 
 POST sends a POST request to the portal. Use this to submit a new metadata and generate an accession/ID.
+
+### PATCH
+
+PATCH will send a patch request to the portal in order to patch properties of **SELECTED** columns. Only selected columns will be affected by this request. Properties in other columns will not be included in the request.
 
 ### PUT (Admin only)
 
 PUT sends a PUT request to the portal so that the whole metadata on the portal is replaced with a row on the sheet. **Beware that this will remove any missing properties on the sheet from the portal**.
 
 Before you PUT to the portal, make sure to GET the metadata with GET (ADMIN) first.
+
+
+### Attachment
+
+For a profile with `attachment` property (e.g. `document` profile), you can define `attachment` column as a JSON string `{"path":"/GOOGLE/DRIVE/PATH/TO/FILE/me.pdf"}`.
+
+It is recommended to make a local directory for document files only on your computer, and then drag and drop the folder itself to your Google Drive. Then all files in it will be transferred to Google Drive while keeping the directory structure.
+
+
+### Local file uploading (sidebar)
+
+You can directly upload local files to portal's S3 bucket on the upload sidebar. Use it after POSTing metadata to the portal. Make sure that there is at least one identifying property in the header (e.g. `accession`, `uuid`).
+
+Click on menu `IGVF` - `Upload local files (sidebar)` and it will automatically add two columns to the current sheet: `#upload_status` and `#upload_abspath`. Define absolute paths of files to be uploaded under the column `#upload_abspath`. `#upload_status` will show uploading status.
+
+On the sidebar, you need to drag and drop a root folder that contains all files to be uploaded. Such action is necessary to grant read permission of files to the sidebar. Therefore, make sure that all files are organized under a single root directory.
+
+
+### Local file uploading (S3 command line)
+
+Install AWS CLI first on your local computer/cluster where your files are.
+
+```bash
+$ pip install awscli
+```
+
+Click on menu `IGVF` - `Generate S3 command line for file uploading` and then the script will generate required columns for the feature: `#upload_abspath` and `#upload_cmd`. Define `#upload_abspath` for each row and click on the menu again. Use shell command line under `#upload_cmd` column to manually upload your files to the portal.
 
 
 ## Property legends
@@ -71,19 +97,3 @@ Color and style represents a type of property.
 
 - <span style="text-decoration:underline">Underline</span>: Searchable property
 - ***Italic+Bold***: Array type property
-
-
-## File upload sidebar
-
-You can directly upload local files to portal's S3 bucket on the upload sidebar. Use it after POSTing metadata to the portal. Make sure that there is at least one identifying property in the header (e.g. `accession`, `uuid`).
-
-Click on menu `IGVF/ENCODE` - `Upload local files (sidebar)` and it will automatically create two columns to a current sheet: `#upload_status` and `#upload_abspath`. Define absolute paths of files to be uploaded under the column #`#upload_abspath`. `#upload_status` will show uploading status.
-
-On the sidebar, you need to drag and drop a root folder that contains all files to be uploaded. Such action is necessary to grant read permission of files to the sidebar. Therefore, make sure that all files are organized under a single root directory.
-
-
-## Attachment
-
-For a profile with `attachment` property (e.g. `document` profile), you can define `attachment` column as a JSON string `{"path":"/GOOGLE/DRIVE/PATH/TO/FILE/me.pdf"}`.
-
-It is recommended to make a local directory for document files only on your computer, and then drag and drop the folder itself to your Google Drive. Then all files in it will be transferred to Google Drive while keeping the directory structure.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ $ sudo npm i @google/clasp@2.3.0 -g
 
 Create with a new Google Spreadsheet with the script.
 ```bash
-$ npx clasp create --type sheets --title "IGVF Metadata Submitter v0.2.7" --rootDir ./dist
+$ npx clasp create --type sheets --title "IGVF Metadata Submitter v0.2.7 (WRN-453)" --rootDir ./dist
 ```
 
 Get the script ID from the output and edit `scriptId` in `.clasp.json`.
@@ -42,8 +42,7 @@ $ npm run deploy
 
 Make a copy of this portable version and grant any required permissions.
 
-`v0.2.7`: https://docs.google.com/spreadsheets/d/1fq1Tk297428Zc5J1B22Tcv9wFuPRRjp6Osr8a1LjRSo/edit?usp=sharing
-
+`v0.2.7 (WRN-453)`: https://docs.google.com/spreadsheets/d/1gWEHGdi0eNjaX1mmC3FrgHFntfhWMib3ipQeas3ukzI/edit?usp=sharing
 
 ## Settings
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ $ sudo npm i @google/clasp@2.3.0 -g
 
 Create with a new Google Spreadsheet with the script.
 ```bash
-$ npx clasp create --type sheets --title "IGVF Metadata Submitter v0.2.7 (WRN-446)" --rootDir ./dist
+$ npx clasp create --type sheets --title "IGVF Metadata Submitter v0.2.7 (WRN-453)" --rootDir ./dist
 ```
 
 Get the script ID from the output and edit `scriptId` in `.clasp.json`.
@@ -42,8 +42,7 @@ $ npm run deploy
 
 Make a copy of this portable version and grant any required permissions.
 
-`v0.2.7 (WRN-446)`: https://docs.google.com/spreadsheets/d/1fq1Tk297428Zc5J1B22Tcv9wFuPRRjp6Osr8a1LjRSo/edit?usp=sharing
-
+`v0.2.7 (WRN-453)`: https://docs.google.com/spreadsheets/d/1gWEHGdi0eNjaX1mmC3FrgHFntfhWMib3ipQeas3ukzI/edit?usp=sharing
 
 ## Settings
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ $ sudo npm i @google/clasp@2.3.0 -g
 
 Create with a new Google Spreadsheet with the script.
 ```bash
-$ npx clasp create --type sheets --title "IGVF Metadata Submitter v0.2.7 (WRN-453)" --rootDir ./dist
+$ npx clasp create --type sheets --title "IGVF Metadata Submitter v0.3.0" --rootDir ./dist
 ```
 
 Get the script ID from the output and edit `scriptId` in `.clasp.json`.
@@ -42,7 +42,7 @@ $ npm run deploy
 
 Make a copy of this portable version and grant any required permissions.
 
-`v0.2.7 (WRN-453)`: https://docs.google.com/spreadsheets/d/1gWEHGdi0eNjaX1mmC3FrgHFntfhWMib3ipQeas3ukzI/edit?usp=sharing
+`v0.3.0`: https://docs.google.com/spreadsheets/d/1gWEHGdi0eNjaX1mmC3FrgHFntfhWMib3ipQeas3ukzI/edit?usp=sharing
 
 ## Settings
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ IGVF metadata submitter based on Google Sheet + Google Apps Script.
 
 Make a copy of the following spreadsheet.
 
-`v0.3.0`: https://docs.google.com/spreadsheets/d/1gWEHGdi0eNjaX1mmC3FrgHFntfhWMib3ipQeas3ukzI/edit?usp=sharing
+`v0.3.0`: https://docs.google.com/spreadsheets/d/1SC1SgERoA4SGi6-M4w4kSsXLuLNlR2lnxkzXj-lYdGc/edit?usp=sharing
 
 Click on the menu item `IGVF` and then `Authorize for IGVF`. You will see an error message `Authorization Required`. Click on `Continue`, choose your Google account. Click on `Advanced` and `Go to IGVF Metadata Submitter (unsafe)` and then click on `Allow`.
 

--- a/appsscript.json
+++ b/appsscript.json
@@ -19,6 +19,7 @@
   "exceptionLogging": "STACKDRIVER",
   "oauthScopes": [
     "https://www.googleapis.com/auth/spreadsheets",
+    "https://www.googleapis.com/auth/drive.readonly",
     "https://www.googleapis.com/auth/script.external_request",
     "https://www.googleapis.com/auth/script.container.ui"
   ]

--- a/functions/Endpoint.js
+++ b/functions/Endpoint.js
@@ -7,7 +7,7 @@ curl "https://www.encodeproject.org/profiles/?format=json&frame=object" \
   | jq | perl -ne '/\/profiles\/(.+).json/ and print "  \"$1\",\n";' | sort | uniq
 
 
-ALL_IGVF_PROFILES from "ORDER" array in the following file (snapshotted at 09/25/2023)
+ALL_IGVF_PROFILES from "ORDER" array in the following file (snapshotted at 09/27/2023)
 It's an ordered list of profiles:
   https://github.com/IGVF-DACC/igvfd/blob/dev/src/igvfd/loadxl.py#L15
 

--- a/functions/Endpoint.js
+++ b/functions/Endpoint.js
@@ -7,7 +7,11 @@ curl "https://www.encodeproject.org/profiles/?format=json&frame=object" \
   | jq | perl -ne '/\/profiles\/(.+).json/ and print "  \"$1\",\n";' | sort | uniq
 
 
-ALL_IGVF_PROFILES from the following command line (snapshotted at 09/06/2023)
+ALL_IGVF_PROFILES from "ORDER" array in the following file (snapshotted at 09/25/2023)
+It's an ordered list of profiles:
+  https://github.com/IGVF-DACC/igvfd/blob/dev/src/igvfd/loadxl.py#L15
+
+Double-check it with profiles retrieved with the following command line
 
 curl "https://api.data.igvf.org/profiles?format=json&frame=object" \
   | jq | perl -ne '/\/profiles\/(.+).json/ and print "  \"$1\",\n";' | sort | uniq
@@ -183,53 +187,53 @@ const CORE_SET_ENCODE_PROFILES = [
 ];
 
 const ALL_IGVF_PROFILES = [
-  "access_key",
-  "alignment_file",
-  "analysis_set",
-  "analysis_step",
-  "assay_term",
-  "auxiliary_set",
+  "user",
   "award",
-  "biomarker",
-  "configuration_file",
-  "construct_library",
-  "construct_library_set",
-  "curated_set",
+  "source",
+  "lab",
   "document",
   "gene",
-  "human_donor",
-  "human_genomic_variant",
-  "image",
-  "in_vitro_system",
-  "lab",
-  "matrix_file",
-  "measurement_set",
-  "model",
-  "model_set",
-  "modification",
-  "multiplexed_sample",
-  "page",
-  "phenotype_term",
-  "phenotypic_feature",
-  "platform_term",
-  "prediction",
-  "prediction_set",
-  "primary_cell",
-  "publication",
-  "reference_file",
-  "rodent_donor",
   "sample_term",
-  "sequence_file",
-  "signal_file",
+  "assay_term",
+  "phenotype_term",
+  "platform_term",
+  "phenotypic_feature",
+  "human_donor",
+  "rodent_donor",
+  "treatment",
+  "modification",
+  "human_genomic_variant",
+  "biomarker",
+  "tissue",
+  "in_vitro_system",
+  "primary_cell",
+  "technical_sample",
+  "whole_organism",
+  "multiplexed_sample",
+  "curated_set",
   "software",
   "software_version",
-  "source",
-  "technical_sample",
-  "tissue",
-  "treatment",
-  "user",
-  "whole_organism",
+  "construct_library",
+  "construct_library_set",
+  "image",
+  "page",
   "workflow",
+  "publication",
+  "access_key",
+  "measurement_set",
+  "analysis_set",
+  "model",
+  "model_set",
+  "auxiliary_set",
+  "prediction",
+  "prediction_set",
+  "reference_file",
+  "sequence_file",
+  "signal_file",
+  "alignment_file",
+  "configuration_file",
+  "matrix_file",
+  "analysis_step"
 ];
 
 const CORE_SET_IGVF_PROFILES = [

--- a/functions/Endpoint.js
+++ b/functions/Endpoint.js
@@ -178,6 +178,10 @@ const ALL_ENCODE_PROFILES = [
   "user",
   "worm_donor",
 ];
+const CORE_SET_ENCODE_PROFILES = [
+  "experiment",
+];
+
 const ALL_IGVF_PROFILES = [
   "access_key",
   "alignment_file",
@@ -226,6 +230,12 @@ const ALL_IGVF_PROFILES = [
   "user",
   "whole_organism",
   "workflow",
+];
+
+const CORE_SET_IGVF_PROFILES = [
+  "document",
+  "measurement_set",
+  "sequence_file",
 ];
 
 function isEncodeEndpoint(endpoint) {
@@ -284,3 +294,10 @@ function getIgvfEndpointsAvailableForUsers() {
   return IGVF_ENDPOINTS.filter(e => e !== ENDPOINT_IGVF_TEST);
 }
 
+function getCoreSetProfiles(endpoint) {
+  if (isEncodeEndpoint(endpoint)) {
+    return CORE_SET_ENCODE_PROFILES;
+  } else if (isIgvfEndpoint(endpoint)) {
+    return CORE_SET_IGVF_PROFILES;
+  }
+}

--- a/functions/Endpoint.js
+++ b/functions/Endpoint.js
@@ -17,9 +17,6 @@ curl "https://api.data.igvf.org/profiles?format=json&frame=object" \
 const ENCODE = "ENCODE";
 const IGVF = "IGVF";
 
-const PROPERTY_DEFAULT_ENDPOINT_READ = "defaultEndpointRead";
-const PROPERTY_DEFAULT_ENDPOINT_WRITE = "defaultEndpointWrite";
-
 // These are API endpoints.
 // If there is a UI endpoint then add it to ENDPOINT_MAP_API_TO_UI below
 // Otherwise, the script will use the same endpoint for API and UI

--- a/functions/Endpoint.js
+++ b/functions/Endpoint.js
@@ -236,6 +236,24 @@ const ALL_IGVF_PROFILES = [
   "analysis_step"
 ];
 
+const IGVF_PROFILES_EXCLUSION_LIST_FOR_TEMPLATE_GENERATION = [
+  "access_key",
+  "award",
+  "lab",
+  "gene",
+  "assay_term",
+  "phenotype_term",
+  "platform_term",
+  "sample_term",
+  "page",
+  "source",
+  "user",
+  "human_genomic_variant",
+  "construct_library",
+  "prediction",
+  "model",
+];
+
 const CORE_SET_IGVF_PROFILES = [
   "document",
   "measurement_set",
@@ -298,10 +316,12 @@ function getIgvfEndpointsAvailableForUsers() {
   return IGVF_ENDPOINTS.filter(e => e !== ENDPOINT_IGVF_TEST);
 }
 
-function getCoreSetProfiles(endpoint) {
+function getAllProfilesForTemplateGeneration(endpoint) {
   if (isEncodeEndpoint(endpoint)) {
-    return CORE_SET_ENCODE_PROFILES;
+    return ALL_ENCODE_PROFILES;
   } else if (isIgvfEndpoint(endpoint)) {
-    return CORE_SET_IGVF_PROFILES;
+    // apply exclusion list for igvf profiles
+    return ALL_IGVF_PROFILES
+      .filter(item => !IGVF_PROFILES_EXCLUSION_LIST_FOR_TEMPLATE_GENERATION.includes(item));
   }
 }

--- a/functions/GoogleDrive.js
+++ b/functions/GoogleDrive.js
@@ -1,0 +1,38 @@
+
+function testGoogleDrive() {
+    var path = "/test_submitter_attachment/aaaa/ok.tsv";
+    var file = getDriveFileFromPath(path);
+    Logger.log(readDriveFile(file));
+}
+
+function readDriveFile(file) {
+  return file.getBlob().getDataAsString();
+}
+
+function guessContentType(path) {
+}
+
+function getDriveFileFromPath(path) {
+  var basename = getBasename(path);
+  var dirname = getDirname(path);
+
+  var folder = getDriveFolderFromPath(dirname);
+  console.log(folder.getName());
+  var files = folder.getFilesByName(basename);
+  if (files.hasNext()) {
+    return files.next();
+  }
+}
+
+// code from: https://ramblings.mcpher.com/gassnippets2/finding-a-drive-app-folder-by-path/
+function getDriveFolderFromPath(path) {
+  return (path || "/").split(/[\\/]/).reduce( function(prev,current) {
+    if (prev && current) {
+      var fldrs = prev.getFoldersByName(current);
+      return fldrs.hasNext() ? fldrs.next() : null;
+    }
+    else {
+      return current ? null : prev;
+    }
+  },DriveApp.getRootFolder());
+}

--- a/functions/GoogleDrive.js
+++ b/functions/GoogleDrive.js
@@ -1,23 +1,9 @@
-
-function testGoogleDrive() {
-    var path = "/test_submitter_attachment/aaaa/ok.tsv";
-    var file = getDriveFileFromPath(path);
-    Logger.log(readDriveFile(file));
-}
-
-function readDriveFile(file) {
-  return file.getBlob().getDataAsString();
-}
-
-function guessContentType(path) {
-}
-
 function getDriveFileFromPath(path) {
   var basename = getBasename(path);
   var dirname = getDirname(path);
 
   var folder = getDriveFolderFromPath(dirname);
-  console.log(folder.getName());
+
   var files = folder.getFilesByName(basename);
   if (files.hasNext()) {
     return files.next();

--- a/functions/Library.js
+++ b/functions/Library.js
@@ -91,3 +91,13 @@ function openUrl( url ){
   .setWidth( 90 ).setHeight( 1 );
   SpreadsheetApp.getUi().showModalDialog( html, "Opening ..." );
 }
+
+function getBasename(path) {
+  return path.split(/[\\/]/).pop();
+}
+
+function getDirname(path) {
+  var array = path.split(/[\\/]/);
+  array.pop();
+  return array.join("/");
+}

--- a/functions/Metadata.js
+++ b/functions/Metadata.js
@@ -197,6 +197,31 @@ function findIdentifyingPropValColInRow(sheet, row, profile) {
   return [undefined, undefined, undefined];
 }
 
+function setAttachment(attachmentJson) {
+  // attachmentJson has "path" property only
+  var path = attachmentJson["path"];
+  var file = getDriveFileFromPath(path);
+
+  if (!file) {
+    alertBox(`${path} not found on Google Drive.`);
+    return;
+  }
+
+  var mimeType = file.getMimeType();
+  if (mimeType === "application/x-gzip") {
+    mimeType = "application/gzip";
+  }
+
+  var base64EncodedStr = Utilities.base64Encode(file.getBlob().getBytes());
+
+  var attachment = {
+    download: path,
+    type: mimeType,
+    href: `data:${mimeType};base64,${base64EncodedStr}`
+  }
+  return attachment;
+}
+
 function submitSheetToPortal(
   sheet, profileName, endpointForPut, endpointForProfile, method, selectedColsForPatch=[]
 ) {
@@ -224,6 +249,21 @@ function submitSheetToPortal(
     var json = typeCastJsonValuesByProfile(
       profile, jsonBeforeTypeCast, keepCommentedProps=false
     );
+
+    // if there is an attachment (e.g. document profile)
+    // then read from Google Drive, base64encode its content
+    if (
+      hasAttachment(profile) &&
+      json.hasOwnProperty(HEADER_PROP_ATTACHMENT) &&
+      json[HEADER_PROP_ATTACHMENT]
+    ) {
+      // overwrite on payload's attachment
+      var attachment = setAttachment(json[HEADER_PROP_ATTACHMENT]);
+      if (!attachment) {
+        continue;
+      }
+      json[HEADER_PROP_ATTACHMENT] = attachment;
+    }
 
     var payloadJson = {};
 

--- a/functions/Metadata.js
+++ b/functions/Metadata.js
@@ -450,8 +450,7 @@ function createNewSheetAndGetMetadata(sheet, profileName, endpoint) {
   }
 
   // copy DeleveoptMetadata (endpoints and profile name) to new sheet
-  setEndpointRead(newSheet, getEndpointRead(sheet));
-  setEndpointWrite(newSheet, getEndpointWrite(sheet));
+  setEndpoint(newSheet, getEndpoint(sheet));
   setProfileName(newSheet, getProfileName(sheet));
 
   // run GET on new sheet to get metadata from the portal

--- a/functions/Metadata.js
+++ b/functions/Metadata.js
@@ -401,14 +401,6 @@ function validateSheet(sheet, profileName, endpointForProfile) {
   return numSubmitted;
 }
 
-function addMetadataTemplateToSheet(sheet, profile, forAdmin=false) {
-  var metadataObj = makeMetadataTemplateFromProfile(profile, forAdmin);
-  var sortedProps = getSortedProps(Object.keys(metadataObj), profile);
-  addJsonToSheet(sheet, metadataObj, sortedProps);
-  // for schema version checking
-  setLastUsedSchemaVersion(sheet, getProfileSchemaVersion(profile));
-}
-
 function createNewSheetAndGetMetadata(sheet, profileName, endpoint) {
   // Copy current sheet's identifying columns to a new sheet
   // and then do GET to get latest metadata from the portal
@@ -434,7 +426,7 @@ function createNewSheetAndGetMetadata(sheet, profileName, endpoint) {
   var schemaVersion = getProfileSchemaVersion(profile);
   var newSheetName = `${currentSheetName}_v${schemaVersion}`;
   if (spreadsheet.getSheetByName(newSheetName)) {
-    alertBox(`Faild to create a new sheet, it already exists: ${newSheetName}`);
+    alertBox(`Faild to create a new sheet since it already exists: ${newSheetName}.`);
     return;
   }
 
@@ -449,8 +441,7 @@ function createNewSheetAndGetMetadata(sheet, profileName, endpoint) {
     currentNewSheetCol++;
   }
 
-  // copy DeleveoptMetadata (endpoints and profile name) to new sheet
-  setEndpoint(newSheet, getEndpoint(sheet));
+  // copy DeveloperMetadata (profile name) to new sheet
   setProfileName(newSheet, getProfileName(sheet));
 
   // run GET on new sheet to get metadata from the portal

--- a/functions/Metadata.js
+++ b/functions/Metadata.js
@@ -197,11 +197,18 @@ function findIdentifyingPropValColInRow(sheet, row, profile) {
   return [undefined, undefined, undefined];
 }
 
+
 function setAttachment(attachmentJson) {
   // attachmentJson has "path" property only
   var path = attachmentJson["path"];
-  var file = getDriveFileFromPath(path);
+  if (!path) {
+    alertBox(
+      'attachment is not a valid JSON string. A valid example format is {"path": "/GOOGLE/DRIVE/PATH/file.pdf"}.'
+    );
+    return;
+  }
 
+  var file = getDriveFileFromPath(path);
   if (!file) {
     alertBox(`${path} not found on Google Drive.`);
     return;

--- a/functions/Metadata.js
+++ b/functions/Metadata.js
@@ -222,7 +222,7 @@ function setAttachment(attachmentJson) {
   var base64EncodedStr = Utilities.base64Encode(file.getBlob().getBytes());
 
   var attachment = {
-    download: path,
+    download: getBasename(path),
     type: mimeType,
     href: `data:${mimeType};base64,${base64EncodedStr}`
   }

--- a/functions/MetadataTemplate.js
+++ b/functions/MetadataTemplate.js
@@ -39,5 +39,4 @@ function createNewSheetAndMakeTemplate(profileName, endpoint) {
   // create a new sheet (no need to set focus on it)
   var newSheet = createNewSheet(profileName, false);
   setProfileName(newSheet, profileName);
-  // makeTemplate(newSheet, forAdmin=false);
 }

--- a/functions/MetadataTemplate.js
+++ b/functions/MetadataTemplate.js
@@ -7,7 +7,7 @@ function makeMetadataTemplateFromProfile(profile, forAdmin=false, template=DEFAU
   // add all properties except for non-editable ones
   // if default exists for a prop then use it
   // otherwise use null for prop
-  var result = template;
+  var result = JSON.parse(JSON.stringify(template));
   for (var prop of Object.keys(profile["properties"])) {
     if (!isPostableProp(profile, prop, forAdmin)) {
       continue;
@@ -17,4 +17,27 @@ function makeMetadataTemplateFromProfile(profile, forAdmin=false, template=DEFAU
   }
 
   return result;
+}
+
+function addMetadataTemplateToSheet(sheet, profile, forAdmin=false) {
+  var metadataObj = makeMetadataTemplateFromProfile(profile, forAdmin);
+  var sortedProps = getSortedProps(Object.keys(metadataObj), profile);
+  addJsonToSheet(sheet, metadataObj, sortedProps);
+  // for schema version checking
+  setLastUsedSchemaVersion(sheet, getProfileSchemaVersion(profile));
+}
+
+function createNewSheetAndMakeTemplate(profileName, endpoint) {
+  var spreadsheet = SpreadsheetApp.getActive();
+  var profile = getProfile(profileName, endpoint);
+
+  if (spreadsheet.getSheetByName(profileName)) {
+    alertBox(`Faild to create a new sheet since it already exists: ${profileName}.`);
+    return;
+  }
+
+  // create a new sheet (no need to set focus on it)
+  var newSheet = createNewSheet(profileName, false);
+  setProfileName(newSheet, profileName);
+  // makeTemplate(newSheet, forAdmin=false);
 }

--- a/functions/Profile.js
+++ b/functions/Profile.js
@@ -410,7 +410,7 @@ function checkProfile() {
   var profileName = getProfileName();
 
   if (getProfileName()) {
-    var profile = getProfile(getProfileName(), getEndpointRead())
+    var profile = getProfile(getProfileName(), getEndpoint())
 
     if (!profile) {
       alertBox(

--- a/functions/Profile.js
+++ b/functions/Profile.js
@@ -305,8 +305,19 @@ function makeTooltipForProp(profile, prop) {
     .map(key => {return `* ${key}\n${propInProfile[key]}`})
     .join('\n\n');
 
+  // find linkTo for Array type and add it to tooltip
   if (propInProfile.hasOwnProperty("items") && propInProfile.items.hasOwnProperty("linkTo")) {
     tooltip += `\n\n* linkTo\n${propInProfile.items.linkTo}`;
+  }
+
+  // find submissionExample for Array type and add it to tooltip
+  if (propInProfile.hasOwnProperty("submissionExample")) {
+    if (propInProfile.submissionExample.hasOwnProperty("appscript")) {
+      tooltip += `\n\n* submissionExample (appscript)\n${propInProfile.submissionExample.appscript}`;
+    }
+    if (propInProfile.submissionExample.hasOwnProperty("igvf_utils")) {
+      tooltip += `\n\n* submissionExample (igvf_utils)\n${propInProfile.submissionExample.igvf_utils}`;
+    }
   }
 
   // additionally find comment in dependency and add to tooltip

--- a/functions/Profile.js
+++ b/functions/Profile.js
@@ -5,6 +5,7 @@ const HEADER_PROP_ALIASES = "aliases";
 const HEADER_PROP_AWARD = "award";
 const HEADER_PROP_LAB = "lab";
 const HEADER_PROP_S3_URI = "s3_uri";
+const HEADER_PROP_ATTACHMENT = "attachment";
 const BIG_NUMBER_FOR_PRIORITY_SORTING = 1000;
 
 // determines the column order of properties in the header
@@ -170,6 +171,11 @@ function hasDoNotSubmitInPropComment(profile, prop) {
   var propInProfile = profile["properties"][prop];
   return propInProfile.hasOwnProperty("comment") &&
     propInProfile["comment"].toLowerCase().startsWith("do not submit");
+}
+
+function hasAttachment(profile) {
+  return profile["properties"].hasOwnProperty(HEADER_PROP_ATTACHMENT) &&
+    profile["properties"][HEADER_PROP_ATTACHMENT]["attachment"];
 }
 
 function isAdminOrSystemProp(profile, prop) {

--- a/functions/Profile.js
+++ b/functions/Profile.js
@@ -67,7 +67,6 @@ function isValidProfileName(profileName, endpoint) {
     // make capitalized sentence from snakecase 
     var capitalizedName = capitalizeWord(snakeToCamel(name));
     if ([name, capitalizedName].includes(profileName)) {
-      Logger.log(profileName + " " + name + " " + capitalizedName);
       return true;
     }
   }
@@ -374,7 +373,8 @@ function highlightHeaderAndDataCell(sheet, profile) {
 
     if (!isCommentedProp(profile, prop) && !profile["properties"].hasOwnProperty(prop)) {
       Logger.info(
-        `Property ${prop} does not exist in current profile\n\nPossible mismatch between profile and accession?`
+        `Property ${prop} does not exist in current profile(${profile.title})\n\n` +
+        "Possible mismatch between profile and accession?"
       );
       missingProps.push(prop);
       continue;

--- a/functions/Profile.js
+++ b/functions/Profile.js
@@ -441,6 +441,6 @@ function checkProfile() {
 
   alertBox(
     "No profile name found.\n" +
-    "Go to the menu 'IGVF' -> 'Settings & auth' to define it."
+    'Go to the menu "IGVF" -> "Set profile name".'
   );
 }

--- a/functions/Profile.js
+++ b/functions/Profile.js
@@ -59,7 +59,8 @@ const SELECTED_PROP_KEYS_FOR_TOOLTIP = [
   "comment",
   "type",
   "readonly",
-  "notSubmittable"
+  "notSubmittable",
+  "linkTo",
 ];
 
 function isValidProfileName(profileName, endpoint) {
@@ -304,10 +305,6 @@ function makeTooltipForProp(profile, prop) {
     .map(key => {return `* ${key}\n${propInProfile[key]}`})
     .join('\n\n');
 
-  // additionally find linkTo profile and add to tooltip
-  if (propInProfile.hasOwnProperty("linkTo")) {
-    tooltip += `\n\n* linkTo\n${propInProfile.linkTo}`;
-  }
   if (propInProfile.hasOwnProperty("items") && propInProfile.items.hasOwnProperty("linkTo")) {
     tooltip += `\n\n* linkTo\n${propInProfile.items.linkTo}`;
   }

--- a/functions/Profile.js
+++ b/functions/Profile.js
@@ -304,10 +304,18 @@ function makeTooltipForProp(profile, prop) {
     .map(key => {return `* ${key}\n${propInProfile[key]}`})
     .join('\n\n');
 
+  // additionally find linkTo profile and add to tooltip
+  if (propInProfile.hasOwnProperty("linkTo")) {
+    tooltip += `\n\n* linkTo\n${propInProfile.linkTo}`;
+  }
+  if (propInProfile.hasOwnProperty("items") && propInProfile.items.hasOwnProperty("linkTo")) {
+    tooltip += `\n\n* linkTo\n${propInProfile.items.linkTo}`;
+  }
+
   // additionally find comment in dependency and add to tooltip
   var dependencyProp = getPropInDependentSchemas(profile, prop)
   if (dependencyProp && dependencyProp.hasOwnProperty("comment")) {
-    tooltip += `\n\n* dependency\n${dependencyProp["comment"]}`
+    tooltip += `\n\n* dependency\n${dependencyProp["comment"]}`;
   }
 
   return tooltip;

--- a/functions/Sheet.js
+++ b/functions/Sheet.js
@@ -352,12 +352,32 @@ function rowToJson(sheet, row, keepCommentedProps, bypassGoogleAutoParsing) {
 }
 
 function createNewSheet(newSheetName, activate=false) {  
-    var spreadsheet = SpreadsheetApp.getActive();
-    var newSheet = spreadsheet.insertSheet();
-    newSheet.setName(newSheetName);
+  var spreadsheet = SpreadsheetApp.getActive();
+  var newSheet = spreadsheet.insertSheet();
+  newSheet.setName(newSheetName);
 
-    if (activate) {
-      newSheet.activate();
+  if (activate) {
+    newSheet.activate();
+  }
+  return newSheet;
+}
+
+function insertColumnLeftmostWithHeadersAndTooltips(sheet, headers, tooltips, skipExistingHeader=true) {
+  // insert columns to the leftmost with headers array
+  // can skip existing header
+  for (var i = 0; i < headers.length; i++) {
+    var header = headers[i];
+
+    if (skipExistingHeader && findColumnByHeaderValue(sheet, header)) {
+      continue;
     }
-    return newSheet;
+    const col = 1;
+    sheet.insertColumnBefore(col);
+    sheet.getRange(HEADER_ROW, col).setValue(header);
+
+    if (tooltips) {
+      var tooltip = tooltips[i];
+      setCellTooltip(sheet, HEADER_ROW, col, tooltip);
+    }
+  }
 }

--- a/functions/SheetData.js
+++ b/functions/SheetData.js
@@ -74,7 +74,7 @@ function setProfileName(sheet, input) {
     `* Current profile name:\\n${getProfileName(sheet)}\\n\\n` +
     "Snakecase (with _) or capitalized CamelCase are allowed for a profile name.\\n" +
     "No plural (s) is allowed in profile name.\\n" +
-    "(e.g. MeasurementSet, measurement_set, lab):\\n\\n" +
+    "(e.g. MeasurementSet, measurement_set, sequence_file, lab):\\n\\n" +
     "Enter a new profile name:"
   );
   if (getProfileName(sheet) && getProfileName(sheet) !== profileName) {

--- a/functions/SheetData.js
+++ b/functions/SheetData.js
@@ -95,7 +95,7 @@ function setProfileName(sheet, input) {
   // if sheet is empty then make a template row automatically
   var currentSheet = sheet ? sheet : getCurrentSheet();
   if (isSheetEmpty(currentSheet)) {
-    makeTemplate(currentSheet, forAdmin=false);
+    makeTemplate(currentSheet, forAdmin=false, newSheet=true);
   }
 }
 

--- a/functions/SheetData.js
+++ b/functions/SheetData.js
@@ -24,14 +24,14 @@ function getDefaultEndpoint() {
   return defaultEndpoint ? defaultEndpoint : DEFAULT_ENDPOINT_WRITE
 }
 
-function getEndpoint(sheet) {
+function getEndpoint() {
   // As of 0.3.0, it's just a wrapper for default endpoint
   return getDefaultEndpoint();
 }
 
 function getProfileName(sheet) {
   var profileName = getSheetDevMetadata(
-    sheet !== undefined ? sheet : getCurrentSheet(),
+    sheet ? sheet : getCurrentSheet(),
     KEY_PROFILE_NAME
   );
   return profileName ? profileName : null;
@@ -39,13 +39,13 @@ function getProfileName(sheet) {
 
 function getLastUsedSchemaVersion(sheet) {
   return getSheetDevMetadata(
-    sheet !== undefined ? sheet : getCurrentSheet(),
+    sheet ? sheet : getCurrentSheet(),
     KEY_LAST_USED_SCHEMA_VERSION
   );
 }
 
 function setDefaultEndpoint(input) {
-  var endpoint = input !== undefined ? input : Browser.inputBox(
+  var endpoint = input ? input : Browser.inputBox(
     `* Current endpoint:\\n${getDefaultEndpoint()}\\n\\n` +
     "* Supported IGVF endpoints:\\n" +
     `${getIgvfEndpointsAvailableForUsers().join("\\n")}\\n\\n` +
@@ -70,7 +70,7 @@ function setEndpoint(sheet, input) {
 }
 
 function setProfileName(sheet, input) {    
-  var profileName = input !== undefined ? input : Browser.inputBox(
+  var profileName = input ? input : Browser.inputBox(
     `* Current profile name:\\n${getProfileName(sheet)}\\n\\n` +
     "Snakecase (with _) or capitalized CamelCase are allowed for a profile name.\\n" +
     "No plural (s) is allowed in profile name.\\n" +
@@ -88,24 +88,24 @@ function setProfileName(sheet, input) {
     return;
   }
   setSheetDevMetadata(
-    sheet !== undefined ? sheet : getCurrentSheet(),
+    sheet ? sheet : getCurrentSheet(),
     KEY_PROFILE_NAME,
     profileName
   );
   // if sheet is empty then make a template row automatically
-  var currentSheet = sheet !== undefined ? sheet : getCurrentSheet();
+  var currentSheet = sheet ? sheet : getCurrentSheet();
   if (isSheetEmpty(currentSheet)) {
-    makeTemplate(forAdmin=false);
+    makeTemplate(currentSheet, forAdmin=false);
   }
 }
 
 function setLastUsedSchemaVersion(sheet, input) {
-  var schemaVersion = input !== undefined ? input : Browser.inputBox(
+  var schemaVersion = input ? input : Browser.inputBox(
     `* Current sheet's last used schema version:\\n${getLastUsedSchemaVersion(sheet)}\\n\\n` +
     "Enter a new schema version:"
   );
   setSheetDevMetadata(
-    sheet !== undefined ? sheet : getCurrentSheet(),
+    sheet ? sheet : getCurrentSheet(),
     KEY_LAST_USED_SCHEMA_VERSION,
     schemaVersion
   );
@@ -113,7 +113,7 @@ function setLastUsedSchemaVersion(sheet, input) {
 
 function resetLastUsedSchemaVersion(sheet) {
   setSheetDevMetadata(
-    sheet !== undefined ? sheet : getCurrentSheet(),
+    sheet ? sheet : getCurrentSheet(),
     KEY_LAST_USED_SCHEMA_VERSION,
     undefined
   );
@@ -121,7 +121,7 @@ function resetLastUsedSchemaVersion(sheet) {
 
 function showSheetAllDevMetadata(sheet) {
   var allMetadata = getSheetAllDevMetadata(
-    sheet !== undefined ? sheet : getCurrentSheet()
+    sheet ? sheet : getCurrentSheet()
   );
   alertBox(JSON.stringify(allMetadata, null, 4));
 }

--- a/functions/Tests.js
+++ b/functions/Tests.js
@@ -1,0 +1,20 @@
+function testGoogleDrive() {
+    var paths = [
+      // "/test_submitter_attachment/aaaa/ENCFF356LFX.bed.gz",
+      // "/test_submitter_attachment/aaaa/ok.tsv",
+      // "/test_submitter_attachment/aaaa/file_example_TIFF_1MB.tiff",
+      // "/test_submitter_attachment/aaaa/image.png",
+      "/test_submitter_attachment/aaaa/mmce_1_2_1_userguide.pdf",
+      // "/test_submitter_attachment/aaaa/outputs.json",
+      "/test_submitter_attachment/aaaa/x.jpg",
+    ];
+    for (path of paths) {
+      var file = getDriveFileFromPath(path);
+
+      var mimeType = file.getMimeType();
+      Logger.log(`${path}: ${mimeType}`);
+
+      var base64EncodedStr = Utilities.base64Encode(file.getBlob().getBytes());
+      Logger.log(base64EncodedStr);
+    }
+}

--- a/functions/Upload.js
+++ b/functions/Upload.js
@@ -33,7 +33,7 @@ function openUploadSidebar() {
 }
 
 function getUploadCredentialsFromFileId(fileId) {
-  var endPoint = getEndpointWrite();
+  var endPoint = getEndpoint();
 
   var url = `${endPoint}/${fileId}@@upload?format=json&frame=object`;
   var response = restGet(url);
@@ -54,7 +54,7 @@ function getUploadCredentialsFromIdentifyingVal(identifyingVal) {
 }
 
 function getFileStatusAndErrorFromFileId(fileId) {
-  var endPoint = getEndpointWrite();
+  var endPoint = getEndpoint();
 
   var url = `${endPoint}/${fileId}?format=json&frame=object`;
   var response = restGet(url);
@@ -83,7 +83,7 @@ function initUpload() {
   }
 
   var sheet = getCurrentSheet();
-  var profile = getProfile(getProfileName(), getEndpointRead());
+  var profile = getProfile(getProfileName(), getEndpoint());
 
   // check if identifying property exists
   if (profile["identifyingProperties"]

--- a/functions/Upload.js
+++ b/functions/Upload.js
@@ -2,27 +2,28 @@ const UPLOAD_CREDENTIALS = "upload_credentials";
 const IDENTIFYING_VAL = "identifying_val";
 const IDENTIFYING_PROP = "identifying_prop";
 
+const TOOLTIP_HEADER_COMMENTED_PROP_UPLOAD_ABSPATH = "Define absolute paths of files for each row to be uploaded.";
+const TOOLTIP_HEADER_COMMENTED_PROP_UPLOAD_STATUS = "Shows status of uploading.";
+const TOOLTIP_HEADER_COMMENTED_PROP_UPLOAD_CMD = 'Shows "aws s3api" command line to manually upload local files.';
 
 function openUploadSidebar() {
   var sheet = getCurrentSheet();
 
-  if ( !findColumnByHeaderValue(sheet, HEADER_COMMENTED_PROP_UPLOAD_ABSPATH) ) {
-    alertBox(
-      `Add a column ${HEADER_COMMENTED_PROP_UPLOAD_ABSPATH} to the header row and try again.`
-    );
-    return
-  }
-  if ( !findColumnByHeaderValue(sheet, HEADER_COMMENTED_PROP_UPLOAD_STATUS) ) {
-    alertBox(
-      `Add a column ${HEADER_COMMENTED_PROP_UPLOAD_STATUS} to the header row and try again.`
-    );
-    return
-  }
-  if ( !findColumnByHeaderValue(sheet, HEADER_COMMENTED_PROP_UPLOAD_CMD) ) {
-    alertBox(
-      `Add a column ${HEADER_COMMENTED_PROP_UPLOAD_CMD} to the header row and try again.`
-    );
-    return
+  if ( !findColumnByHeaderValue(sheet, HEADER_COMMENTED_PROP_UPLOAD_ABSPATH)
+    || !findColumnByHeaderValue(sheet, HEADER_COMMENTED_PROP_UPLOAD_STATUS) ) {
+    if (alertBoxOkCancel(
+      "To use file uploading, please add the following commented columns to the header and try again:\n\n"
+      + `${HEADER_COMMENTED_PROP_UPLOAD_ABSPATH} : ${TOOLTIP_HEADER_COMMENTED_PROP_UPLOAD_ABSPATH}\n`
+      + `${HEADER_COMMENTED_PROP_UPLOAD_STATUS} : ${TOOLTIP_HEADER_COMMENTED_PROP_UPLOAD_CMD}\n\n`
+      + "Would you like to add them automatically to the sheet?"
+    )) {
+      insertColumnLeftmostWithHeadersAndTooltips(
+        sheet,
+        [HEADER_COMMENTED_PROP_UPLOAD_ABSPATH, HEADER_COMMENTED_PROP_UPLOAD_STATUS],
+        [TOOLTIP_HEADER_COMMENTED_PROP_UPLOAD_ABSPATH, TOOLTIP_HEADER_COMMENTED_PROP_UPLOAD_STATUS],
+      );
+    }
+    return;
   }
 
   var html = HtmlService.createTemplateFromFile("UploaderSideBar.html");
@@ -155,11 +156,6 @@ function initUpload() {
     const [,,bucket,] = uploadCredentials["upload_url"].split("/");
     const key = uploadCredentials["upload_url"].split("/").splice(3).join("/");
 
-    const cmd =
-      `AWS_ACCESS_KEY_ID="${accessKeyId}" AWS_SECRET_ACCESS_KEY="${secretAccessKey}" AWS_SESSION_TOKEN="${sessionToken}" ` +
-      `aws s3api put-object --bucket "${bucket}" --key "${key}" --body "${uploadAbsPath}"`;
-    json[HEADER_COMMENTED_PROP_UPLOAD_CMD] = cmd;
-
     // to report status on both sheet and upload sidebar
     // this json object will be passed to the upload sidebar
     if (contentError) {
@@ -195,4 +191,104 @@ function updateStatusOnSheet(sheetName, identifyingProp, identifyingVal, status)
       writeToCell(sheet, row, uploadStatusCol, status);
     }
   }
+}
+
+function generateS3UploadCmd() {
+  if (!checkProfile()) {
+    return;
+  }
+
+  var sheet = getCurrentSheet();
+
+  if ( !findColumnByHeaderValue(sheet, HEADER_COMMENTED_PROP_UPLOAD_ABSPATH)
+    || !findColumnByHeaderValue(sheet, HEADER_COMMENTED_PROP_UPLOAD_CMD) ) {
+    if (alertBoxOkCancel(
+      "To use file uploading, please add the following commented columns to the header and try again:\n\n"
+      + `${HEADER_COMMENTED_PROP_UPLOAD_ABSPATH} : ${TOOLTIP_HEADER_COMMENTED_PROP_UPLOAD_ABSPATH}\n`
+      + `${HEADER_COMMENTED_PROP_UPLOAD_CMD} : ${TOOLTIP_HEADER_COMMENTED_PROP_UPLOAD_CMD}\n\n`
+      + "Would you like to add them automatically to the sheet?"
+    )) {
+      insertColumnLeftmostWithHeadersAndTooltips(
+        sheet,
+        [HEADER_COMMENTED_PROP_UPLOAD_ABSPATH, HEADER_COMMENTED_PROP_UPLOAD_CMD],
+        [TOOLTIP_HEADER_COMMENTED_PROP_UPLOAD_ABSPATH, TOOLTIP_HEADER_COMMENTED_PROP_UPLOAD_CMD],
+      );
+    }
+    return;
+  }
+
+  var profile = getProfile(getProfileName(), getEndpoint());
+
+  // check if identifying property exists
+  if (profile["identifyingProperties"]
+    .filter(prop => findColumnByHeaderValue(sheet, prop))
+    .length === 0) {
+    alertBox(
+      `Couldn't find an identifying property (${profile["identifyingProperties"].join(",")}) in header row ${HEADER_ROW}\n\n` +
+      `Add a proper identifying property to the header row and define it for each data row to retrieve from the portal.`
+    );
+    return;
+  }
+
+  const numData = getNumMetadataInSheet(sheet);
+  var results = [];
+
+  for (var row = HEADER_ROW + 1; row <= numData + HEADER_ROW; row++) {
+    var json = rowToJson(
+      sheet, row, keepCommentedProps=true, bypassGoogleAutoParsing=true,
+    );
+
+    // if row is hidden, then skip
+    if (isRowHidden(sheet, row)) {
+      continue;
+    }
+    // if has #skip and it is 1 then skip
+    if (json.hasOwnProperty(HEADER_COMMENTED_PROP_SKIP)) {
+      if (toBoolean(json[HEADER_COMMENTED_PROP_SKIP])) {
+        continue;
+      }
+    }
+    var [identifyingProp, identifyingVal, identifyingCol] =
+      findIdentifyingPropValColInRow(sheet, row, profile);
+
+    // check status of file
+    var {status, contentError} = getFileStatusAndErrorFromIdentifyingVal(identifyingVal);
+
+    // prevent re-uploading to a released object
+    if (status == "released") {
+      json[HEADER_COMMENTED_PROP_UPLOAD_STATUS] = "error: uploading to a released accession is not allowed.";
+      writeJsonToRow(sheet, json, row);
+      continue;
+    }
+
+    var uploadAbsPathCol = findColumnByHeaderValue(sheet, HEADER_COMMENTED_PROP_UPLOAD_ABSPATH);
+    var uploadAbsPath = uploadAbsPathCol ? getCellValue(sheet, row, uploadAbsPathCol) : undefined;
+
+    if (!uploadAbsPath) {
+      json[HEADER_COMMENTED_PROP_UPLOAD_STATUS] = `Missing ${HEADER_COMMENTED_PROP_UPLOAD_ABSPATH}.`;
+      writeJsonToRow(sheet, json, row);
+      continue;
+    }
+
+    // get upload credentials from portal
+    var uploadCredentials = getUploadCredentialsFromIdentifyingVal(identifyingVal);
+    if (!uploadCredentials) {
+      json[HEADER_COMMENTED_PROP_UPLOAD_STATUS] = "Failed to get upload credentials.";
+      writeJsonToRow(sheet, json, row);
+      continue;
+    }
+    const accessKeyId = uploadCredentials["access_key"];
+    const secretAccessKey = uploadCredentials["secret_key"];
+    const sessionToken = uploadCredentials["session_token"];
+    const [,,bucket,] = uploadCredentials["upload_url"].split("/");
+    const key = uploadCredentials["upload_url"].split("/").splice(3).join("/");
+
+    const cmd =
+      `AWS_ACCESS_KEY_ID="${accessKeyId}" AWS_SECRET_ACCESS_KEY="${secretAccessKey}" AWS_SESSION_TOKEN="${sessionToken}" ` +
+      `aws s3api put-object --bucket "${bucket}" --key "${key}" --body "${uploadAbsPath}"`;
+    json[HEADER_COMMENTED_PROP_UPLOAD_CMD] = cmd;
+
+    writeJsonToRow(sheet, json, row);
+  }
+
 }

--- a/functions/UserInterface.js
+++ b/functions/UserInterface.js
@@ -456,9 +456,6 @@ function updateCurrentSheet() {
   updateSheet(currentSheet);
 }
 
-function updateAllSheets() {
-}
-
 function updateSheet(sheet) {
   var endpoint = getEndpoint();
 
@@ -486,9 +483,9 @@ function updateSheet(sheet) {
   createNewSheetAndGetMetadata(sheet, profileName, endpoint);
 }
 
-function createSheetsForCoreSetProfiles() {
+function createSheetsForAllProfiles() {
   var endpoint = getEndpoint();
-  var profiles = getCoreSetProfiles(endpoint);
+  var profiles = getAllProfilesForTemplateGeneration(endpoint);
 
   // check if sheet with profile name already exists
   var spreadsheet = SpreadsheetApp.getActive();
@@ -507,4 +504,5 @@ function createSheetsForCoreSetProfiles() {
   for (var profileName of profiles) {
     createNewSheetAndMakeTemplate(profileName, endpoint);
   }
+  alertBox("Successfully created template sheets for all profiles.");
 }

--- a/functions/UserInterface.js
+++ b/functions/UserInterface.js
@@ -68,7 +68,7 @@ function showSheetInfoAndHeaderLegend() {
     "- red: required property\n" +
     "- blue: identifying property\n" +
     "- black: other editable property\n" +
-    "- gray: ADMIN only property (readonly,nonSubmittable,'Do not sumit')\n\n" +
+    "- gray: ADMIN only property (readonly,nonSubmittable,'Do not submit')\n\n" +
 
     "* Commented properties (filtered out when being sent to the portal)\n" +
     "- #skip: Set it to 1 to skip any READ/WRITE REST action for a row.\n" +

--- a/functions/UserInterface.js
+++ b/functions/UserInterface.js
@@ -23,8 +23,8 @@ function search() {
     return;
   }
   var currentProp = getCellValue(sheet, HEADER_ROW, currentCol);
-  var profile = getProfile(getProfileName(), getEndpointRead());
-  var endpoint = getEndpointRead();
+  var profile = getProfile(getProfileName(), getEndpoint());
+  var endpoint = getEndpoint();
 
   var url = makeSearchUrlForProp(profile, currentProp, endpoint);
 
@@ -49,7 +49,7 @@ function openProfilePage() {
   }
 
   openUrl(
-    makeProfileUrl(getProfileName(), getEndpointRead(), format="page")
+    makeProfileUrl(getProfileName(), getEndpoint(), format="page")
   );
 }
 
@@ -59,16 +59,10 @@ function openToolGithubPage() {
 
 function showSheetInfoAndHeaderLegend() {
   alertBox(
-    "* Settings (Current sheet)\n" +
-    `- Endpoint READ (GET, profile): ${getEndpointRead()}\n` +
-    `- Endpoint WRITE (POST/PATCH/PUT): ${getEndpointWrite()}\n` +
+    "* Settings\n" +
+    `- Endpoint: ${getEndpoint()}\n` +
     `- Profile name: ${getProfileName()}\n` +
-    `- Last used schema version: ${getLastUsedSchemaVersion()}\n\n` +
-
-    "* Settings (Global)\n" +
-    `- Endpoint READ (GET, profile): ${getDefaultEndpointRead()}\n` +
-    `- Endpoint WRITE (POST/PATCH/PUT): ${getDefaultEndpointWrite()}\n` +
-    `- Profile name: ${getDefaultProfileName()}\n\n` +
+    `- Last used schema version of profile: ${getLastUsedSchemaVersion()}\n\n` +
 
     "* Color legends for header properties\n" +
     "- red: required property\n" +
@@ -94,7 +88,7 @@ function applyProfileToSheet() {
   }
 
   var sheet = getCurrentSheet();
-  var profile = getProfile(getProfileName(), getEndpointRead());
+  var profile = getProfile(getProfileName(), getEndpoint());
 
   // clear tooltip and dropdown menus
   clearFontColorInSheet(sheet);
@@ -122,7 +116,7 @@ function makeTemplate(forAdmin=false) {
   }
 
   var sheet = getCurrentSheet();
-  var profile = getProfile(getProfileName(), getEndpointRead());
+  var profile = getProfile(getProfileName(), getEndpoint());
 
   addMetadataTemplateToSheet(sheet, profile, forAdmin);
 
@@ -144,7 +138,7 @@ function getMetadataForAll(forAdmin, showWarning=true) {
   }
 
   var sheet = getCurrentSheet();
-  var profile = getProfile(getProfileName(), getEndpointRead());
+  var profile = getProfile(getProfileName(), getEndpoint());
 
   if (profile["identifyingProperties"]
     .filter(prop => findColumnByHeaderValue(sheet, prop))
@@ -165,7 +159,7 @@ function getMetadataForAll(forAdmin, showWarning=true) {
   }
 
   var numUpdated = updateSheetWithMetadataFromPortal(
-    sheet, getProfileName(), getEndpointRead(), getEndpointRead(), forAdmin,
+    sheet, getProfileName(), getEndpoint(), getEndpoint(), forAdmin,
   );
   if (showWarning) {
     alertBox(`Updated ${numUpdated} rows.`);
@@ -181,8 +175,7 @@ function saveSheetSpecificSettings() {
   // it's recommended to do this everytime after communicating with the portal
 
   var sheet = getCurrentSheet();
-  setEndpointRead(sheet, getEndpointRead(sheet));
-  setEndpointWrite(sheet, getEndpointWrite(sheet));
+  setEndpoint(sheet, getEndpoint(sheet));
   setProfileName(sheet, getProfileName(sheet));
 }
 
@@ -200,7 +193,7 @@ function validateJsonWithSchema() {
   }
 
   var numSubmitted = validateSheet(
-    getCurrentSheet(), getProfileName(), getEndpointRead()
+    getCurrentSheet(), getProfileName(), getEndpoint()
   );
   alertBox(`Validated ${numSubmitted} rows.`);
 }
@@ -218,7 +211,7 @@ function convertSelectedRowToJson() {
   }
 
   var json = convertRowToJson(
-    sheet, currentRow, getProfileName(), getEndpointRead(), keepCommentedProps=false
+    sheet, currentRow, getProfileName(), getEndpoint(), keepCommentedProps=false
   );
   var jsonText = JSON.stringify(json, null, EXPORTED_JSON_INDENT);
 
@@ -246,14 +239,14 @@ function putAll() {
     "PUT action will REPLACE metadata on the portal with those on the sheet. " +
     "Therefore, any properties missing on the sheet will also be REMOVED from portal's metadata." +
     "If you are not an admin and just want to patch non-empty values of properties on the sheet, use PATCH instead.\n\n" +
-    `Are you sure to PUT to ${getEndpointWrite()}?`)) {
+    `Are you sure to PUT to ${getEndpoint()}?`)) {
     return;
   }
 
   var numSubmitted = submitSheetToPortal(
-    sheet, getProfileName(), getEndpointWrite(), getEndpointRead(), method="PUT"
+    sheet, getProfileName(), getEndpoint(), getEndpoint(), method="PUT"
   );
-  alertBox(`Submitted (PUT) ${numSubmitted} rows to ${getEndpointWrite()}.`);
+  alertBox(`Submitted (PUT) ${numSubmitted} rows to ${getEndpoint()}.`);
 }
 
 function patchSelected() {
@@ -278,15 +271,15 @@ function patchSelected() {
     `Found ${numData} data row(s).\n\n` +
     "PATCH action will REPLACE properties on the portal with data on selected columns only.\n\n" +
     `Selected properties: ${selectedCols.map(x => x.headerProp).join(",")}` + "\n\n" +
-    `Are you sure to PATCH to ${getEndpointWrite()}?`)) {
+    `Are you sure to PATCH to ${getEndpoint()}?`)) {
     return;
   }
 
   var numSubmitted = submitSheetToPortal(
-    sheet, getProfileName(), getEndpointWrite(), getEndpointRead(), method="PATCH",
+    sheet, getProfileName(), getEndpoint(), getEndpoint(), method="PATCH",
     selectedColsForPatch=selectedCols,
   );
-  alertBox(`PATCHed ${numSubmitted} rows to ${getEndpointWrite()}.`);
+  alertBox(`PATCHed ${numSubmitted} rows to ${getEndpoint()}.`);
 
   applyProfileToSheet();
   saveSheetSpecificSettings();
@@ -307,14 +300,14 @@ function patchAll() {
   if (!alertBoxOkCancel(
     `Found ${numData} data row(s).\n\n` + 
     "PATCH action will REPLACE properties on the portal with data on the sheet.\n\n" +
-    `Are you sure to PATCH to ${getEndpointWrite()}?`)) {
+    `Are you sure to PATCH to ${getEndpoint()}?`)) {
     return;
   } 
 
   var numSubmitted = submitSheetToPortal(
-    sheet, getProfileName(), getEndpointWrite(), getEndpointRead(), method="PATCH"
+    sheet, getProfileName(), getEndpoint(), getEndpoint(), method="PATCH"
   );
-  alertBox(`Submitted (PATCH) ${numSubmitted} rows to ${getEndpointWrite()}.`);
+  alertBox(`Submitted (PATCH) ${numSubmitted} rows to ${getEndpoint()}.`);
 }
 
 function postAll() {
@@ -336,14 +329,14 @@ function postAll() {
     "No other properties/values will be updated on the sheet even though some new properties with " +
     "default values are assigned to them on the portal.\n\n" +
     `You can add ${HEADER_COMMENTED_PROP_SKIP} column and set it to 1 for a row that you want to skip REST actions.\n\n` +
-    `Are you sure to POST to ${getEndpointWrite()}?`)) {
+    `Are you sure to POST to ${getEndpoint()}?`)) {
     return;
   }
 
   var numSubmitted = submitSheetToPortal(
-    sheet, getProfileName(), getEndpointWrite(), getEndpointRead(), method="POST"
+    sheet, getProfileName(), getEndpoint(), getEndpoint(), method="POST"
   );
-  alertBox(`Submitted (POST) ${numSubmitted} rows to ${getEndpointWrite()}.`);
+  alertBox(`Submitted (POST) ${numSubmitted} rows to ${getEndpoint()}.`);
 
   applyProfileToSheet();
   saveSheetSpecificSettings();
@@ -357,7 +350,7 @@ function exportToJsonText() {
   var sheet = getCurrentSheet();
 
   var json = exportSheetToJson(
-    sheet, getProfileName(), getEndpointRead(),
+    sheet, getProfileName(), getEndpoint(),
     keepCommentedProps=false,
   );
 
@@ -381,7 +374,7 @@ function exportToJson() {
   );
 
   exportSheetToJsonFile(
-    sheet, getProfileName(), getEndpointRead(),
+    sheet, getProfileName(), getEndpoint(),
     keepCommentedProps=false,
     jsonFilePath=jsonFilePath,
   );
@@ -474,7 +467,7 @@ function updateAllSheets() {
 }
 
 function updateSheet(sheet) {
-  var endpoint = getEndpointRead(sheet);
+  var endpoint = getEndpoint(sheet);
 
   // check if profile exists
   var profileName = getProfileName(sheet);

--- a/functions/Version.js
+++ b/functions/Version.js
@@ -1,4 +1,4 @@
-SCRIPT_VERSION='v0.2.7';
+SCRIPT_VERSION='v0.3.0';
 URL_LATEST_SCRIPT_VERSION='https://api.github.com/repos/igvf-dacc/igvf-metadata-submitter/releases/latest';
 URL_PREFIX_UPDATE_HELP='https://github.com/IGVF-DACC/igvf-metadata-submitter/blob/';
 URL_SUFFIX_UPDATE_HELP='/UPDATE.md';

--- a/src/server/menu.js
+++ b/src/server/menu.js
@@ -4,7 +4,7 @@ global.onOpen = () => {
 
   menu.addItem('Search', 'search');
   menu.addSeparator();
-  menu.addItem("Set profile name", 'setProfileName');
+  menu.addItem('Set profile name', 'setProfileName');
   menu.addItem('Show sheet info', 'showSheetInfoAndHeaderLegend');
   menu.addSeparator();
   menu.addItem('Validate', 'validateJsonWithSchema');
@@ -14,23 +14,20 @@ global.onOpen = () => {
   menu.addItem('PATCH selected columns', 'patchSelected');
   menu.addItem('PATCH all columns', 'patchAll');
   menu.addSeparator();
-  menu.addItem('Create a new sheet with updated profile schema', 'updateCurrentSheet');
-  menu.addSeparator();
   menu.addItem('File upload sidebar', 'uploadSidebar');
-  menu.addSeparator();
-  menu.addItem('Export selected row to JSON', 'convertSelectedRowToJson');
-  // menu.addItem('PATCH-APPEND selected columns', 'patchAppendAll');
-  // menu.addItem('PATCH-REMOVE selected columns', 'patchRemoveAll');
   menu.addSeparator();
 
   const submenuTools = SpreadsheetApp.getUi().createMenu('🛠 Tools');
   submenuTools.addItem('Make a new template row', 'makeTemplateForUser');
   submenuTools.addItem('Highlight sheet with profile schema', 'applyProfileToSheet');
   submenuTools.addSeparator();
-  submenuTools.addItem('Open profile page', 'openProfilePage');
+  submenuTools.addItem('Create a new sheet with updated profile schema', 'updateCurrentSheet');
   submenuTools.addSeparator();
+  submenuTools.addItem('Export selected row to JSON', 'convertSelectedRowToJson');
   submenuTools.addItem('Export sheet to JSON', 'exportToJsonText');
   submenuTools.addItem('Export sheet to JSON file (Google Drive)', 'exportToJson');
+  submenuTools.addSeparator();
+  submenuTools.addItem('Open profile page', 'openProfilePage');
   submenuTools.addSeparator();
   submenuTools.addItem('Make a new template row (ADMIN ONLY)', 'makeTemplateForAdmin');
   submenuTools.addItem('GET metadata from portal (ADMIN ONLY)', 'getMetadataForAllForAdmin');

--- a/src/server/menu.js
+++ b/src/server/menu.js
@@ -41,6 +41,7 @@ global.onOpen = () => {
   submenuDeveloper.addItem('Show spreadsheet developer metadata', 'showSpreadsheetAllDevMetadata');
   submenuDeveloper.addItem("Set current sheet's last used schema version", 'setLastUsedSchemaVersion');
   submenuDeveloper.addItem('Authorize for ENCODE', 'authorizeForEncode');
+  // submenuDeveloper.addItem('Test Google Drive', 'testGoogleDrive');
   submenuTools.addSubMenu(submenuDeveloper);
   menu.addSubMenu(submenuTools);
   menu.addSeparator();

--- a/src/server/menu.js
+++ b/src/server/menu.js
@@ -3,66 +3,55 @@ global.onOpen = () => {
   const menu = SpreadsheetApp.getUi().createMenu(`IGVF ${version}`);
 
   menu.addItem('Search', 'search');
-  menu.addItem('File upload sidebar', 'uploadSidebar');
   menu.addSeparator();
+  menu.addItem("Set profile name", 'setProfileName');
   menu.addItem('Show sheet info', 'showSheetInfoAndHeaderLegend');
-  menu.addSeparator();
-  menu.addItem('Check for script update', 'checkForUpdate');
-  menu.addSeparator();
-  menu.addItem('Update current sheet schema version', 'updateCurrentSheet');
-  // menu.addItem('Update all sheets', 'updateAllSheets');
   menu.addSeparator();
   menu.addItem('Validate', 'validateJsonWithSchema');
   menu.addSeparator();
-  menu.addItem('Export selected row to JSON', 'convertSelectedRowToJson');
-  menu.addSeparator();
-  menu.addItem('Make new template row', 'makeTemplateForUser');
   menu.addItem('GET metadata from portal', 'getMetadataForAllForUser');
   menu.addItem('POST new metadata to portal', 'postAll');
   menu.addItem('PATCH selected columns', 'patchSelected');
   menu.addItem('PATCH all columns', 'patchAll');
+  menu.addSeparator();
+  menu.addItem('Create a new sheet with updated profile schema', 'updateCurrentSheet');
+  menu.addSeparator();
+  menu.addItem('File upload sidebar', 'uploadSidebar');
+  menu.addSeparator();
+  menu.addItem('Export selected row to JSON', 'convertSelectedRowToJson');
   // menu.addItem('PATCH-APPEND selected columns', 'patchAppendAll');
   // menu.addItem('PATCH-REMOVE selected columns', 'patchRemoveAll');
   menu.addSeparator();
 
   const submenuTools = SpreadsheetApp.getUi().createMenu('🛠 Tools');
-  submenuTools.addItem('Make new template row (ADMIN ONLY)', 'makeTemplateForAdmin');
-  submenuTools.addItem('GET metadata from portal (ADMIN ONLY)', 'getMetadataForAllForAdmin');
-  submenuTools.addItem('PUT metadata to portal (ADMIN ONLY)', 'putAll');
+  submenuTools.addItem('Make a new template row', 'makeTemplateForUser');
+  submenuTools.addItem('Highlight sheet with profile schema', 'applyProfileToSheet');
   submenuTools.addSeparator();
   submenuTools.addItem('Open profile page', 'openProfilePage');
-  submenuTools.addItem('Apply profile to sheet manually', 'applyProfileToSheet');
   submenuTools.addSeparator();
   submenuTools.addItem('Export sheet to JSON', 'exportToJsonText');
   submenuTools.addItem('Export sheet to JSON file (Google Drive)', 'exportToJson');
-  submenuTools.addItem("Open tool's github page for README", 'openToolGithubPage');
+  submenuTools.addSeparator();
+  submenuTools.addItem('Make a new template row (ADMIN ONLY)', 'makeTemplateForAdmin');
+  submenuTools.addItem('GET metadata from portal (ADMIN ONLY)', 'getMetadataForAllForAdmin');
+  submenuTools.addItem('PUT metadata to portal (ADMIN ONLY)', 'putAll');
+
   const submenuDeveloper = SpreadsheetApp.getUi().createMenu('🛠 Developers only (for debugging)');
   submenuDeveloper.addItem('Show current sheet developer metadata', 'showSheetAllDevMetadata');
   submenuDeveloper.addItem('Show spreadsheet developer metadata', 'showSpreadsheetAllDevMetadata');
   submenuDeveloper.addItem("Set current sheet's last used schema version", 'setLastUsedSchemaVersion');
+  submenuDeveloper.addSeparator();
   submenuDeveloper.addItem('Authorize for ENCODE', 'authorizeForEncode');
-  // submenuDeveloper.addItem('Test Google Drive', 'testGoogleDrive');
   submenuTools.addSubMenu(submenuDeveloper);
+
   menu.addSubMenu(submenuTools);
   menu.addSeparator();
 
-  const submenuAuth = SpreadsheetApp.getUi().createMenu('⚙️ Authorization');
-  submenuAuth.addItem('Authorize for IGVF', 'authorizeForIgvf');
-  menu.addSubMenu(submenuAuth);
-
-  const submenuSettingsGlobal = SpreadsheetApp.getUi().createMenu('⚙️ Settings (Global)');
-  submenuSettingsGlobal.addItem('Set default endpoint for READs (GET)', 'setDefaultEndpointRead');
-  submenuSettingsGlobal.addItem('Set default endpoint for WRITEs (POST/PATCH/PUT)', 'setDefaultEndpointWrite');
-  submenuSettingsGlobal.addSeparator();
-  submenuSettingsGlobal.addItem('Set default profile name', 'setDefaultProfileName');
-  menu.addSubMenu(submenuSettingsGlobal);
-
-  const submenuSettingsSheet = SpreadsheetApp.getUi().createMenu('⚙️ Settings (Current sheet)');
-  submenuSettingsSheet.addItem('Set endpoint for READs (GET)', 'setEndpointRead');
-  submenuSettingsSheet.addItem('Set endpoint for WRITEs (POST/PATCH/PUT)', 'setEndpointWrite');
-  submenuSettingsSheet.addSeparator();
-  submenuSettingsSheet.addItem('Set profile name', 'setProfileName');
-  menu.addSubMenu(submenuSettingsSheet);
+  menu.addItem('Authorize for IGVF', 'authorizeForIgvf');
+  menu.addItem('Set endpoint', 'setDefaultEndpoint');
+  menu.addSeparator();
+  menu.addItem('Check for script update', 'checkForUpdate');
+  menu.addItem("Open tool's github page for README", 'openToolGithubPage');
 
   menu.addToUi();
 };

--- a/src/server/menu.js
+++ b/src/server/menu.js
@@ -25,6 +25,8 @@ global.onOpen = () => {
   submenuTools.addSeparator();
   submenuTools.addItem('Create a new sheet with updated profile schema', 'updateCurrentSheet');
   submenuTools.addSeparator();
+  submenuTools.addItem('Create template sheets for all profiles', 'createSheetsForAllProfiles');
+  submenuTools.addSeparator();
   submenuTools.addItem('Export selected row to JSON', 'convertSelectedRowToJson');
   submenuTools.addItem('Export sheet to JSON', 'exportToJsonText');
   submenuTools.addItem('Export sheet to JSON file (Google Drive)', 'exportToJson');
@@ -32,6 +34,7 @@ global.onOpen = () => {
   submenuTools.addItem('Make a new template row (ADMIN ONLY)', 'makeTemplateForAdmin');
   submenuTools.addItem('GET metadata from portal (ADMIN ONLY)', 'getMetadataForAllForAdmin');
   submenuTools.addItem('PUT metadata to portal (ADMIN ONLY)', 'putAll');
+  submenuTools.addSeparator();
 
   const submenuDeveloper = SpreadsheetApp.getUi().createMenu('🛠 Developers only (for debugging)');
   submenuDeveloper.addItem('Show current sheet developer metadata', 'showSheetAllDevMetadata');
@@ -39,8 +42,6 @@ global.onOpen = () => {
   submenuDeveloper.addItem("Set current sheet's last used schema version", 'setLastUsedSchemaVersion');
   submenuDeveloper.addSeparator();
   submenuDeveloper.addItem('Authorize for ENCODE', 'authorizeForEncode');
-  submenuDeveloper.addSeparator();
-  submenuDeveloper.addItem('Create template sheets for core set profiles', 'createSheetsForCoreSetProfiles');
   submenuTools.addSubMenu(submenuDeveloper);
 
   menu.addSubMenu(submenuTools);

--- a/src/server/menu.js
+++ b/src/server/menu.js
@@ -20,14 +20,13 @@ global.onOpen = () => {
   const submenuTools = SpreadsheetApp.getUi().createMenu('🛠 Tools');
   submenuTools.addItem('Make a new template row', 'makeTemplateForUser');
   submenuTools.addItem('Highlight sheet with profile schema', 'applyProfileToSheet');
+  submenuTools.addItem('Open profile page', 'openProfilePage');
   submenuTools.addSeparator();
   submenuTools.addItem('Create a new sheet with updated profile schema', 'updateCurrentSheet');
   submenuTools.addSeparator();
   submenuTools.addItem('Export selected row to JSON', 'convertSelectedRowToJson');
   submenuTools.addItem('Export sheet to JSON', 'exportToJsonText');
   submenuTools.addItem('Export sheet to JSON file (Google Drive)', 'exportToJson');
-  submenuTools.addSeparator();
-  submenuTools.addItem('Open profile page', 'openProfilePage');
   submenuTools.addSeparator();
   submenuTools.addItem('Make a new template row (ADMIN ONLY)', 'makeTemplateForAdmin');
   submenuTools.addItem('GET metadata from portal (ADMIN ONLY)', 'getMetadataForAllForAdmin');
@@ -39,16 +38,18 @@ global.onOpen = () => {
   submenuDeveloper.addItem("Set current sheet's last used schema version", 'setLastUsedSchemaVersion');
   submenuDeveloper.addSeparator();
   submenuDeveloper.addItem('Authorize for ENCODE', 'authorizeForEncode');
+  submenuDeveloper.addSeparator();
+  submenuDeveloper.addItem('Create template sheets for core set profiles', 'createSheetsForCoreSetProfiles');
   submenuTools.addSubMenu(submenuDeveloper);
 
   menu.addSubMenu(submenuTools);
   menu.addSeparator();
 
-  menu.addItem('Authorize for IGVF', 'authorizeForIgvf');
   menu.addItem('Set endpoint', 'setDefaultEndpoint');
+  menu.addItem('Authorize for IGVF', 'authorizeForIgvf');
   menu.addSeparator();
   menu.addItem('Check for script update', 'checkForUpdate');
-  menu.addItem("Open tool's github page for README", 'openToolGithubPage');
+  menu.addItem('README', 'openToolGithubPage');
 
   menu.addToUi();
 };

--- a/src/server/menu.js
+++ b/src/server/menu.js
@@ -14,7 +14,8 @@ global.onOpen = () => {
   menu.addItem('PATCH selected columns', 'patchSelected');
   menu.addItem('PATCH all columns', 'patchAll');
   menu.addSeparator();
-  menu.addItem('File upload sidebar', 'uploadSidebar');
+  menu.addItem('Upload local files (sidebar)', 'uploadSidebar');
+  menu.addItem('Generate S3 cmd line for file uploading', 'generateS3UploadCmd');
   menu.addSeparator();
 
   const submenuTools = SpreadsheetApp.getUi().createMenu('🛠 Tools');


### PR DESCRIPTION
- Organized/simplified menu items and use only one endpoint for both read/write actions.
- New menu to generate `aws s3api` command line for manually uploading local files.
- New items are added to property tooltip: `dependency`, `linkTo` and `submissionExample`.
- Setting profile name on an empty sheet automatically generate a new template.
- Can generate template sheets for all submittable profiles.
- The script can upload a file from Google Drive for `attachment` property in `document` profile. Example JSON string for `attachment` property:
    ```json
    {"path": "/local/path/on/your/google/drive/me.pdf"}
    ```
