### PR TITLE
WRN-749-new-sheet

### DIFF
--- a/.clasp.json
+++ b/.clasp.json
@@ -1,1 +1,1 @@
-{"scriptId":"1Ah742RpGCbSRLtC3SVNawF__BYQaJPcVyejA19unBtQWFcpnTOPDgQor","rootDir":"./dist"}
+{"scriptId":"15a-iUrZ_vQ5feCXd_G4zqbVHDlQtVnHZMOs8c52gpmET4WmhyDMxhL2e","rootDir":"./dist"}

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ IGVF metadata submitter based on Google Sheet + Google Apps Script.
 
 Make a copy of the following spreadsheet.
 
-`v0.3.4`: https://docs.google.com/spreadsheets/d/1IlmysGDxu4kEUYqr1bMi5WG6NHJqlhcf2ub9-ISWlX4/edit?usp=sharing
+`v0.3.5`: https://docs.google.com/spreadsheets/d/1foX6Jc7c3yeZz7I8H36N93lQMACqny1dRiQOZFG8XZI/edit?usp=sharing
 
 Click on the menu item `IGVF` and then `Authorize for IGVF`. You will see an error message `Authorization Required`. Click on `Continue`, choose your Google account. Click on `Advanced` and `Go to IGVF Metadata Submitter (unsafe)` and then click on `Allow`.
 

--- a/UPDATE.md
+++ b/UPDATE.md
@@ -5,9 +5,9 @@ Please make a copy of original spreadsheet first and run the following on the co
 
 1) Click on the menu `Extensions` - `Apps Script`.
 
-2) Click on `functions.gs` and replace contents with [`functions.gs`](https://github.com/IGVF-DACC/igvf-metadata-submitter/releases/download/v0.3.4/functions.gs).
+2) Click on `functions.gs` and replace contents with [`functions.gs`](https://github.com/IGVF-DACC/igvf-metadata-submitter/releases/download/v0.3.5/functions.gs).
 
-3) Click on `code.gs` and replace contents with [`code.gs`](https://github.com/IGVF-DACC/igvf-metadata-submitter/releases/download/v0.3.4/code.gs).
+3) Click on `code.gs` and replace contents with [`code.gs`](https://github.com/IGVF-DACC/igvf-metadata-submitter/releases/download/v0.3.5/code.gs).
 
 4) Refresh the spreadsheet and check the version number in the `IGVF` menu.
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -15,7 +15,7 @@ $ sudo npm i @google/clasp@2.3.0 -g
 
 Create with a new Google Spreadsheet with the script.
 ```bash
-$ npx clasp create --type sheets --title "IGVF Metadata Submitter v0.3.4" --rootDir ./dist
+$ npx clasp create --type sheets --title "IGVF Metadata Submitter v0.3.5" --rootDir ./dist
 ```
 
 Get the new Google Sheets Add-on script ID from the console output and edit `scriptId` in `.clasp.json`.

--- a/functions/Profile.js
+++ b/functions/Profile.js
@@ -491,6 +491,7 @@ function checkProfileForPost() {
       );
       return;
     }
+    return true;
   }
 
   alertBox(

--- a/functions/Profile.js
+++ b/functions/Profile.js
@@ -460,3 +460,41 @@ function checkProfile() {
     'Go to the menu "IGVF" -> "Set profile name".'
   );
 }
+
+function checkProfileForPost() {
+  // check profile for current sheet
+
+  var profileName = getProfileName();
+
+  if (getProfileName()) {
+    var profile = getProfile(getProfileName(), getEndpoint())
+
+    if (!profile) {
+      alertBox(
+        "Found profile name but couldn't get profile from portal. Wrong credentials?\n" +
+        "Go to the menu 'IGVF' -> 'Authorize for IGVF' and input access key and secret pair."
+      );
+      return;
+    }
+
+    // check schema versions of profile and sheet
+    // if they don't match then halt and show warning
+    const sheetSchemaVersion = getLastUsedSchemaVersion();
+    const profileSchemaVersion = getProfileSchemaVersion(profile);
+
+    if (sheetSchemaVersion && sheetSchemaVersion !== profileSchemaVersion) {
+      alertBox(
+          "Found schema version mismatch (current sheet vs. portal).\n\n" +
+          `- Current sheet's last used schema version: ${sheetSchemaVersion}\n` +
+          `- Portal's latest schema version: ${profileSchemaVersion}\n\n` +
+          "Please create a new tab and pull the latest profile."
+      );
+      return;
+    }
+  }
+
+  alertBox(
+    "No profile name found.\n" +
+    'Go to the menu "IGVF" -> "Set profile name".'
+  );
+}

--- a/functions/UserInterface.js
+++ b/functions/UserInterface.js
@@ -307,7 +307,7 @@ function patchAll() {
 }
 
 function postAll() {
-  if (!checkProfile()) {
+  if (!checkProfileForPost()) {
     return;
   }
 

--- a/functions/Version.js
+++ b/functions/Version.js
@@ -1,4 +1,4 @@
-SCRIPT_VERSION='v0.3.4';
+SCRIPT_VERSION='v0.3.5';
 URL_LATEST_SCRIPT_VERSION='https://api.github.com/repos/igvf-dacc/igvf-metadata-submitter/releases/latest';
 URL_PREFIX_UPDATE_HELP='https://github.com/IGVF-DACC/igvf-metadata-submitter/blob/';
 URL_SUFFIX_UPDATE_HELP='/UPDATE.md';


### PR DESCRIPTION
The script previously will tried to create a new sheet for post action if the version last used is different with the version in portal right now. It will try to find the metadata for the obj from portal. Since the portal will not have any info for a new obj, it will return 404 not found. So we should not try to create a new sheet for the user just warn the user, ask the user to create a new sheet themself, and cancel the action. 